### PR TITLE
Paypal android sdk 2.13.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,6 +23,6 @@ repositories {
 }
 
 dependencies {
-  compile 'com.facebook.react:react-native:0.16.+'
-  compile 'com.paypal.sdk:paypal-android-sdk:2.12.4'
+  compile 'com.facebook.react:react-native:0.18.+'
+  compile 'com.paypal.sdk:paypal-android-sdk:2.13.0'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-paypal",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Native PayPal payment screen for React Native",
   "main": "index.js",
   "repository": {
@@ -21,4 +21,3 @@
   },
   "homepage": "https://github.com/vizir/react-native-paypal"
 }
-


### PR DESCRIPTION
Updated Android PayPal SDK to version 2.13.0 which fixes sandbox payments.
